### PR TITLE
Remove Apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"
   },
   "dependencies": {
-    "@aeternity/aepp-components": "^1.0.4",
+    "@aeternity/aepp-components": "^1.0.7",
     "abi-decoder": "^1.0.9",
     "babel-plugin-transform-es3-member-expression-literals": "^6.22.0",
     "babel-plugin-transform-es3-property-literals": "^6.22.0",

--- a/src/components/AppBrowser.css
+++ b/src/components/AppBrowser.css
@@ -140,8 +140,8 @@ iframe {
 }
 .remove-app-btn{
   position: absolute;
-  top:-10px;
-  right:-10px;
+  top:-12px;
+  right:-12px;
   cursor: pointer;
   visibility: hidden;
   opacity:0;

--- a/src/components/AppBrowser.css
+++ b/src/components/AppBrowser.css
@@ -96,6 +96,12 @@ iframe {
 .app-icon-outer .app-icon{
   margin:0 auto; /* can delete after margins are removed from component */
 }
+.app-browser__notifications{
+  position: fixed;
+  top:0; left:0;
+  width:100%;
+  z-index:200;
+}
 @media screen and (min-width:295px) {
   .app-shortcut {
     width:calc(33.3% - 10px);

--- a/src/components/AppBrowser.css
+++ b/src/components/AppBrowser.css
@@ -138,13 +138,6 @@ iframe {
   z-index:998;
   /*background-color:red;*/
 }
-.no-touch .app-shortcut:hover .remove-app-btn,
-.touch .apps--editmode .remove-app-btn{
-  visibility: visible;
-  opacity:1;
-  transform:scale(1,1);
-  transition: opacity 300ms, transform 300ms, visibility 0s 0s;
-}
 .remove-app-btn{
   position: absolute;
   top:-10px;
@@ -154,4 +147,11 @@ iframe {
   opacity:0;
   transform:scale(.8,.8);
   transition: opacity 300ms, transform 300ms, visibility 0s 300ms;
+}
+.no-touch .app-shortcut:hover .remove-app-btn,
+.touch .apps--editmode .remove-app-btn{
+  visibility: visible;
+  opacity:1;
+  transform:scale(1,1);
+  transition: opacity 300ms, transform 300ms, visibility 0s 0s;
 }

--- a/src/components/AppBrowser.css
+++ b/src/components/AppBrowser.css
@@ -82,10 +82,19 @@ iframe {
   /*background-color:red;*/
 }
 .app-shortcut {
-  margin:5px;
+  position: relative;
+  margin:15px 5px;
   min-width:85px;
   width:calc(50% - 10px);
   /*background-color:green;*/
+  text-align: center;
+}
+.app-icon-outer{
+  position: relative;
+  display: inline-block;
+}
+.app-icon-outer .app-icon{
+  margin:0 auto; /* can delete after margins are removed from component */
 }
 @media screen and (min-width:295px) {
   .app-shortcut {
@@ -117,6 +126,7 @@ iframe {
   }
 }
 .app-name {
+  margin-top: 10px;
   text-align:center;
 }
 .back {
@@ -127,4 +137,21 @@ iframe {
   height:50px;
   z-index:998;
   /*background-color:red;*/
+}
+.no-touch .app-shortcut:hover .remove-app-btn,
+.touch .apps--editmode .remove-app-btn{
+  visibility: visible;
+  opacity:1;
+  transform:scale(1,1);
+  transition: opacity 300ms, transform 300ms, visibility 0s 0s;
+}
+.remove-app-btn{
+  position: absolute;
+  top:-10px;
+  right:-10px;
+  cursor: pointer;
+  visibility: hidden;
+  opacity:0;
+  transform:scale(.8,.8);
+  transition: opacity 300ms, transform 300ms, visibility 0s 300ms;
 }

--- a/src/components/AppBrowser.css
+++ b/src/components/AppBrowser.css
@@ -102,6 +102,13 @@ iframe {
   width:100%;
   z-index:200;
 }
+.app-browser__modal{
+  position: fixed;
+  top:0; let:0;
+  width:100%;
+  height:100%;
+  z-index:950;
+}
 @media screen and (min-width:295px) {
   .app-shortcut {
     width:calc(33.3% - 10px);
@@ -141,7 +148,7 @@ iframe {
   left:5px;
   width:50px;
   height:50px;
-  z-index:998;
+  z-index:900;
   /*background-color:red;*/
 }
 .remove-app-btn{

--- a/src/components/AppBrowser.css
+++ b/src/components/AppBrowser.css
@@ -109,6 +109,17 @@ iframe {
   height:100%;
   z-index:950;
 }
+.ae-modal ul{
+  list-style-type: none;
+  padding:0;
+  display:flex;
+  align-items: center;
+  margin:29px 0 0;
+}
+.ae-modal ul > li{
+  flex:1 0 auto;
+  text-align: center;
+}
 @media screen and (min-width:295px) {
   .app-shortcut {
     width:calc(33.3% - 10px);

--- a/src/components/AppBrowser.css
+++ b/src/components/AppBrowser.css
@@ -140,18 +140,19 @@ iframe {
 }
 .remove-app-btn{
   position: absolute;
-  top:-12px;
-  right:-12px;
+  top:0;
+  right:0;
   cursor: pointer;
   visibility: hidden;
   opacity:0;
-  transform:scale(.8,.8);
+  transform-origin:center center;
+  transform: translate(48%,-50%) scale(.45,.45);
   transition: opacity 300ms, transform 300ms, visibility 0s 300ms;
 }
 .no-touch .app-shortcut:hover .remove-app-btn,
 .touch .apps--editmode .remove-app-btn{
   visibility: visible;
   opacity:1;
-  transform:scale(1,1);
-  transition: opacity 300ms, transform 300ms, visibility 0s 0s;
+  transform: translate(48%,-50%) scale(.58,.58);
+  transition: opacity 300ms 500ms, transform 300ms 500ms, visibility 0s 500ms;
 }

--- a/src/components/AppBrowser.js
+++ b/src/components/AppBrowser.js
@@ -3,6 +3,7 @@ import { AeAppIcon } from '@aeternity/aepp-components'
 import { AeButton } from '@aeternity/aepp-components'
 import { AeIcon } from '@aeternity/aepp-components'
 import { AeNotification } from '@aeternity/aepp-components'
+import { AeModal } from '@aeternity/aepp-components'
 
 export default {
   name: 'app-browser',
@@ -14,7 +15,8 @@ export default {
       isTouch: false,
       editModeActive: false,
       editModeTmOut: null,
-      notifications: []
+      notifications: [],
+      modal: null
     }
   },
   computed : {
@@ -70,9 +72,20 @@ export default {
       }
     },
     remove(name) {
+      this.modal = null
       if(name) {
         this.$store.dispatch('removeApp', name)
       }
+    },
+    confirmRemove (name) {
+      this.modal = {
+        title: `Delete "${name}"?`,
+        message: "You can easily add this œpp again, if you are regretting this action",
+        target: name
+      }
+    },
+    closeModal() {
+      this.modal = null
     },
     editMode(action = null) {
       if (action === 'cancel') return clearTimeout(this.editModeTmOut)
@@ -90,7 +103,8 @@ export default {
      AeAppIcon,
      AeIcon,
      AeButton,
-     AeNotification
+     AeNotification,
+     AeModal
   },
   created () {
     this.setIsTouch()

--- a/src/components/AppBrowser.js
+++ b/src/components/AppBrowser.js
@@ -2,6 +2,7 @@ import QuickId from '@/components/QuickId.vue'
 import { AeAppIcon } from '@aeternity/aepp-components'
 import { AeButton } from '@aeternity/aepp-components'
 import { AeIcon } from '@aeternity/aepp-components'
+import { AeNotification } from '@aeternity/aepp-components'
 
 export default {
   name: 'app-browser',
@@ -12,7 +13,8 @@ export default {
       iframeLoading : true,
       isTouch: false,
       editModeActive: false,
-      editModeTmOut: null
+      editModeTmOut: null,
+      notifications: []
     }
   },
   computed : {
@@ -36,6 +38,14 @@ export default {
       }
       style.display = this.showIframe ? 'block' : 'none'
       return style
+    }
+  },
+  watch: {
+    editModeActive (active) {
+      if (active) {
+        this.notifications.push({type: 'boring', message: "You're now removing œpps"})
+        setTimeout(() => this.notifications.shift(), 3000)
+      }
     }
   },
   methods : {
@@ -70,13 +80,17 @@ export default {
     },
     setIsTouch() {
       this.isTouch = ('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch
+    },
+    doNothing () {
+      // to stop .app-browser @click handler propogation
     }
   },
   components: {
      QuickId,
      AeAppIcon,
      AeIcon,
-     AeButton
+     AeButton,
+     AeNotification
   },
   created () {
     this.setIsTouch()

--- a/src/components/AppBrowser.js
+++ b/src/components/AppBrowser.js
@@ -71,10 +71,6 @@ export default {
       if (action === 'cancel') return clearTimeout(this.editModeTmOut)
       this.editModeTmOut = setTimeout(() => { this.editModeActive = true }, 1000)
     },
-    clickOuter() {
-      console.log('click')
-      this.editModeActive = false
-    },
     setIsTouch() {
       this.isTouch = ('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch
     }

--- a/src/components/AppBrowser.js
+++ b/src/components/AppBrowser.js
@@ -63,10 +63,6 @@ export default {
         this.$store.dispatch('removeApp', name)
       }
     },
-    isRemoveable(name) {
-      const defaultApps = ['Notary', 'Transfer', 'Wall']
-      return name ? defaultApps.indexOf(name) === -1 : true
-    },
     editMode(action = null) {
       if (action === 'cancel') return clearTimeout(this.editModeTmOut)
       this.editModeTmOut = setTimeout(() => { this.editModeActive = true }, 1000)

--- a/src/components/AppBrowser.js
+++ b/src/components/AppBrowser.js
@@ -1,5 +1,6 @@
 import QuickId from '@/components/QuickId.vue'
 import { AeAppIcon } from '@aeternity/aepp-components'
+import { AeButton } from '@aeternity/aepp-components'
 import { AeIcon } from '@aeternity/aepp-components'
 
 export default {
@@ -74,7 +75,8 @@ export default {
   components: {
      QuickId,
      AeAppIcon,
-     AeIcon
+     AeIcon,
+     AeButton
   },
   created () {
     this.setIsTouch()

--- a/src/components/AppBrowser.js
+++ b/src/components/AppBrowser.js
@@ -1,5 +1,6 @@
 import QuickId from '@/components/QuickId.vue'
 import { AeAppIcon } from '@aeternity/aepp-components'
+import { AeIcon } from '@aeternity/aepp-components'
 
 export default {
   name: 'app-browser',
@@ -8,6 +9,9 @@ export default {
       iframe: '',
       showIframe : false,
       iframeLoading : true,
+      isTouch: false,
+      editModeActive: false,
+      editModeTmOut: null
     }
   },
   computed : {
@@ -53,12 +57,35 @@ export default {
       if(url) {
         this.$store.dispatch('addApp', url)
       }
-
     },
+    remove(url) {
+      if(url) {
+        this.$store.dispatch('removeApp', url)
+      }
+    },
+    isRemoveable(name) {
+      const defaultApps = ['Notary', 'Transfer', 'Wall']
+      return name ? defaultApps.indexOf(name) === -1 : true
+    },
+    editMode(action = null) {
+      if (action === 'cancel') return clearTimeout(this.editModeTmOut)
+      this.editModeTmOut = setTimeout(() => { this.editModeActive = true }, 1000)
+    },
+    clickOuter() {
+      console.log('click')
+      this.editModeActive = false
+    },
+    setIsTouch() {
+      this.isTouch = ('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch
+    }
   },
   components: {
      QuickId,
-     AeAppIcon
+     AeAppIcon,
+     AeIcon
+  },
+  created () {
+    this.setIsTouch()
   },
   mounted() {
     console.log(this.$refs)

--- a/src/components/AppBrowser.js
+++ b/src/components/AppBrowser.js
@@ -58,9 +58,9 @@ export default {
         this.$store.dispatch('addApp', url)
       }
     },
-    remove(url) {
-      if(url) {
-        this.$store.dispatch('removeApp', url)
+    remove(name) {
+      if(name) {
+        this.$store.dispatch('removeApp', name)
       }
     },
     isRemoveable(name) {

--- a/src/components/AppBrowser.vue
+++ b/src/components/AppBrowser.vue
@@ -9,7 +9,7 @@
     <div class="apps" :class="{'apps--editmode': editModeActive}">
       <div v-for='app in apps' class="app-shortcut">
         <div class="app-icon-outer" @click="open(app)" @touchstart="editMode" @touchend="editMode('cancel')" @contextmenu.prevent>
-          <div class="remove-app-btn" @click.stop="remove(app.name)" v-if="isRemoveable(app.name)">
+          <div class="remove-app-btn" @click.stop="remove(app.name)">
             <ae-icon name="close" type="exciting"></ae-icon>
           </div>
           <ae-app-icon :src='app.icon'/>

--- a/src/components/AppBrowser.vue
+++ b/src/components/AppBrowser.vue
@@ -36,7 +36,7 @@
       <ae-notification v-for="(item, index) in notifications" :key="index" :type="item.type" @close="notifications.shift()">{{item.message}}</ae-notification>
     </div>
 
-    <ae-modal v-if="modal" :title="modal.title" @close="closeModal">
+    <ae-modal v-if="modal" :title="modal.title" @close="closeModal" :fullscreen="false">
       {{modal.message}}
       <ul>
         <li><ae-button size="smaller" @click="closeModal">CANCEL</ae-button></li>

--- a/src/components/AppBrowser.vue
+++ b/src/components/AppBrowser.vue
@@ -31,7 +31,10 @@
       </div>
     </div>
     <quick-id></quick-id>
-
+    
+    <div class="app-browser__notifications" v-show="notifications.length > 0" @click.stop="doNothing">
+      <ae-notification v-for="(item, index) in notifications" :key="index" :type="item.type" @close="notifications.shift()">{{item.message}}</ae-notification>
+    </div>
   </div>
 </template>
 

--- a/src/components/AppBrowser.vue
+++ b/src/components/AppBrowser.vue
@@ -10,7 +10,9 @@
       <div v-for='app in apps' class="app-shortcut">
         <div class="app-icon-outer" @click="open(app)" @touchstart="editMode" @touchend="editMode('cancel')" @contextmenu.prevent>
           <div class="remove-app-btn" @click.stop="remove(app.name)">
-            <ae-icon name="close" type="exciting"></ae-icon>
+            <ae-button size='small' type='dramatic'>
+              <ae-icon slot='icon' invert type='exciting' name="close"/>
+            </ae-button>
           </div>
           <ae-app-icon :src='app.icon'/>
         </div>

--- a/src/components/AppBrowser.vue
+++ b/src/components/AppBrowser.vue
@@ -9,7 +9,7 @@
     <div class="apps" :class="{'apps--editmode': editModeActive}">
       <div v-for='app in apps' class="app-shortcut">
         <div class="app-icon-outer" @click="open(app)" @touchstart="editMode" @touchend="editMode('cancel')" @contextmenu.prevent>
-          <div class="remove-app-btn" @click.stop="remove(app.main)" v-if="isRemoveable(app.name)">
+          <div class="remove-app-btn" @click.stop="remove(app.name)" v-if="isRemoveable(app.name)">
             <ae-icon name="close" type="exciting"></ae-icon>
           </div>
           <ae-app-icon :src='app.icon'/>

--- a/src/components/AppBrowser.vue
+++ b/src/components/AppBrowser.vue
@@ -1,18 +1,25 @@
 <template>
-  <div class="app-browser screen">
+  <div class="app-browser screen" :class="{'no-touch': !isTouch, 'touch': isTouch}" @click="editModeActive = false">
 
     <div :style='iframeStyle' :class="{'iframe-wrap' : true, loading : iframeLoading}">
       <iframe ref="appframe" id="appframe" class="nomargin" :src="iframe"></iframe>
       <div class="loader"></div>
     </div>
 
-    <div class="apps">
-      <div @click='open(app)' v-for='app in apps' class="app-shortcut">
-        <ae-app-icon :src='app.icon'/>
+    <div class="apps" :class="{'apps--editmode': editModeActive}">
+      <div v-for='app in apps' class="app-shortcut">
+        <div class="app-icon-outer" @click="open(app)" @touchstart="editMode" @touchend="editMode('cancel')" @contextmenu.prevent>
+          <div class="remove-app-btn" @click.stop="remove(app.main)" v-if="isRemoveable(app.name)">
+            <ae-icon name="close" type="exciting"></ae-icon>
+          </div>
+          <ae-app-icon :src='app.icon'/>
+        </div>
         <div class="app-name">{{app.name}}</div>
       </div>
       <div @click='add' class="app-shortcut">
-        <ae-app-icon src='static/icons/notary.svg'/>
+        <div class="app-icon-outer">
+          <ae-app-icon src='static/icons/notary.svg'/>  
+        </div>
         <div class="app-name">Add App</div>
       </div>
     </div>

--- a/src/components/AppBrowser.vue
+++ b/src/components/AppBrowser.vue
@@ -38,10 +38,10 @@
 
     <ae-modal v-if="modal" :title="modal.title" @close="closeModal">
       {{modal.message}}
-      <div class="ae-modal__options">
-        <button @click="closeModal">Cancel</button>
-        <button @click="remove(modal.target)">Delete</button>
-      </div>
+      <ul>
+        <li><ae-button size="smaller" @click="closeModal">CANCEL</ae-button></li>
+        <li><ae-button size="smaller" type="dramatic" @click="remove(modal.target)">DELETE</ae-button></li>
+      </ul>
     </ae-modal>
 
   </div>

--- a/src/components/AppBrowser.vue
+++ b/src/components/AppBrowser.vue
@@ -9,7 +9,7 @@
     <div class="apps" :class="{'apps--editmode': editModeActive}">
       <div v-for='app in apps' class="app-shortcut">
         <div class="app-icon-outer" @click="open(app)" @touchstart="editMode" @touchend="editMode('cancel')" @contextmenu.prevent>
-          <div class="remove-app-btn" @click.stop="remove(app.name)">
+          <div class="remove-app-btn" @click.stop="confirmRemove(app.name)">
             <ae-button size='small' type='dramatic'>
               <ae-icon slot='icon' invert type='exciting' name="close"/>
             </ae-button>
@@ -35,6 +35,15 @@
     <div class="app-browser__notifications" v-show="notifications.length > 0" @click.stop="doNothing">
       <ae-notification v-for="(item, index) in notifications" :key="index" :type="item.type" @close="notifications.shift()">{{item.message}}</ae-notification>
     </div>
+
+    <ae-modal v-if="modal" :title="modal.title" @close="closeModal">
+      {{modal.message}}
+      <div class="ae-modal__options">
+        <button @click="closeModal">Cancel</button>
+        <button @click="remove(modal.target)">Delete</button>
+      </div>
+    </ae-modal>
+
   </div>
 </template>
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -37,6 +37,7 @@ const store = (function () {
       balances: [],
       rpcUrl: 'https://kovan.infura.io',
       keystore: null,
+      defaultApps: ['Notary', 'Transfer', 'Wall'],
       apps : [
         {
           type : APP_TYPES.EXTERNAL,
@@ -77,6 +78,13 @@ const store = (function () {
       addApp( state , app) {
         this.state.apps.push(app);
         localStorage.setItem('apps', JSON.stringify(this.state.apps))
+      },
+      removeApp (state, name) {
+        const appIndex = state.apps.findIndex((app) => app.name === name)
+        if (appIndex > -1) {
+          state.apps.splice(appIndex, 1)
+          localStorage.setItem('apps', JSON.stringify(this.state.apps))
+        }
       },
       setApps ( state , apps) {
         this.state.apps = apps
@@ -193,8 +201,13 @@ const store = (function () {
             }
           })
       },
-      removeApp({commit}, url) {
-        console.log(url)
+      removeApp({commit, state}, name) {
+        if (name) {
+          if (state.defaultApps.indexOf(name) === -1) {
+            console.log(name)
+            commit('removeApp', name)  
+          }
+        }
       },
       logout({getters, dispatch, state, commit}) {
         aeContract = null

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -193,6 +193,9 @@ const store = (function () {
             }
           })
       },
+      removeApp({commit}, url) {
+        console.log(url)
+      },
       logout({getters, dispatch, state, commit}) {
         aeContract = null
         derivedKey = null

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -37,7 +37,6 @@ const store = (function () {
       balances: [],
       rpcUrl: 'https://kovan.infura.io',
       keystore: null,
-      defaultApps: ['Notary', 'Transfer', 'Wall'],
       apps : [
         {
           type : APP_TYPES.EXTERNAL,
@@ -202,12 +201,7 @@ const store = (function () {
           })
       },
       removeApp({commit, state}, name) {
-        if (name) {
-          if (state.defaultApps.indexOf(name) === -1) {
-            console.log(name)
-            commit('removeApp', name)  
-          }
-        }
+        if (name) return commit('removeApp', name)
       },
       logout({getters, dispatch, state, commit}) {
         aeContract = null


### PR DESCRIPTION
Hi, this PR adds a flow for removing apps in the App Browser, with the following behavior on touch/non-touch:

touch device:
- long tap on app icon to enter 'edit mode'
- "X" buttons appear over all apps (like in iOS)
- banner notification with timeout: "You're now removing apps"
- click "X" button > modal appears asking for confirmation

non-touch device:
- long hover on app icon > "X" icon appears
- click "X" icon > modal appears....

If my aeModal with slotted confirm/cancel buttons is merged ([pull request](https://github.com/aeternity/aepp-components/pull/16), you could update the <ae-modal> component in AppBrowser.vue to something like the following:

```
<ae-modal v-if="modal" :title="modal.title" :fullscreen="false" :actionRequired="true" confirmLabel="DELETE" @close="closeModal" @confirm="remove(modal.target)">
    {{modal.message}}
</ae-modal>
```