### PR TITLE
Switch blockies lib

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -46,8 +46,7 @@ module.exports = {
         loader: 'babel-loader',
         include: [
           resolve('src'),
-          resolve('test'),
-          resolve('node_modules/ethereum-blockies-png')
+          resolve('test')
         ]
       },
       {

--- a/build/webpack.test.conf.js
+++ b/build/webpack.test.conf.js
@@ -19,11 +19,12 @@ var webpackConfig = merge(baseConfig, {
           resolve('src'),
           resolve('test'),
           resolve('node_modules/abi-decoder'),
-          resolve('node_modules/web3-provider-engine'),
           resolve('node_modules/dom7'),
           resolve('node_modules/eth-sig-util'),
+          resolve('node_modules/ethereumjs-util'),
           resolve('node_modules/pngjs'),
-          resolve('node_modules/swiper')
+          resolve('node_modules/swiper'),
+          resolve('node_modules/web3-provider-engine')
         ]
       },
     ]

--- a/build/webpack.test.conf.js
+++ b/build/webpack.test.conf.js
@@ -18,7 +18,7 @@ var webpackConfig = merge(baseConfig, {
         include: [
           resolve('src'),
           resolve('test'),
-          resolve('node_modules/ethereum-blockies-png'),
+          resolve('node_modules/abi-decoder'),
           resolve('node_modules/web3-provider-engine'),
           resolve('node_modules/dom7'),
           resolve('node_modules/eth-sig-util'),

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
     "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"
   },
   "dependencies": {
-    "@aeternity/aepp-components": "2.0.0",
+    "@aeternity/aepp-components": "2.0.1",
     "abi-decoder": "^1.0.9",
     "babel-plugin-transform-es3-member-expression-literals": "^6.22.0",
     "babel-plugin-transform-es3-property-literals": "^6.22.0",
     "bignumber.js": "^4.1.0",
     "es6-promise": "^4.1.1",
     "eth-lightwallet": "^3.0.0",
-    "ethereum-blockies-png": "^0.1.2",
+    "ethereum-blockies-png": "git+https://github.com/acdbaykal/ethereum-blockies-png.git",
     "ethjs-unit": "^0.1.6",
     "lodash": "^4.17.4",
     "moment": "^2.19.2",


### PR DESCRIPTION
The ethereum-blockies-png dependency causes problems while testing because it does not provide a transpiled version. I replaced it with a fork I created, which solved the problem.