### PR TITLE
Fix issue 69: Onboarding page not centered at large width

### DIFF
--- a/src/pages/Onboarding/Onboarding.scss
+++ b/src/pages/Onboarding/Onboarding.scss
@@ -6,6 +6,10 @@
     padding: 30px;
   }
 
+  .main-content-container{
+    width: 100%;
+  }
+
   .content {
     margin: auto;
     margin: 30px 60px 30px 30px;

--- a/src/pages/Onboarding/Onboarding.vue
+++ b/src/pages/Onboarding/Onboarding.vue
@@ -4,7 +4,7 @@
       <header>
         <img src="./../../assets/img/header-logo.svg">
       </header>
-      <main>
+      <main class="main-content-container">
         <section id="welcome">
           <div class="cube-div">
             <img src="./../../assets/img/onboarding/identity-card.svg" class="large-copy-2">


### PR DESCRIPTION
I'm waiting for some input from Ray on #69. So this solution might just be a partial one. It does **not** include any limitation an the content's width. But I think we could merge it anyway and I'll create another PR if necessary.
[![on-bording-large.png](https://s13.postimg.org/4npiyvpnr/on-bording-large.png)](https://postimg.org/image/x0l0pcbdv/)