### PR TITLE
Fix issue 71: Delete button for aepps is not always aligned

### DIFF
--- a/src/pages/Apps/Apps.scss
+++ b/src/pages/Apps/Apps.scss
@@ -7,7 +7,7 @@
     justify-items: center;
 
     .app-shortcut {
-      position: relative;
+      text-align: center;
 
       @mixin remove-app-btn-hidden {
         visibility: hidden;
@@ -42,9 +42,17 @@
       }
 
       .app-name {
-        margin-top: 10px;
+        margin-top: 6px;
         text-align: center;
+        &.extra-top-margin {
+          margin-top: 10px;
+        }
       }
     }
+  }
+
+  .close-btn-boundaries {
+    display: inline-block;
+    position: relative;
   }
 }

--- a/src/pages/Apps/Apps.vue
+++ b/src/pages/Apps/Apps.vue
@@ -9,24 +9,28 @@
         @touchend="editMode('cancel')"
         @contextmenu.prevent
       >
-        <ae-button
-          @click="removeAppName = app.name"
-          class="remove-app-btn"
-          :class="{ visible: editModeActive }"
-          type="dramatic"
-          size="small"
-        >
-          <ae-icon slot="icon" invert type="exciting" name="close" />
-        </ae-button>
-        <router-link :to="app.path">
-          <ae-app-icon :src="app.icon" />
-          <div class="app-name">{{app.name}}</div>
-        </router-link>
+          <div class="close-btn-boundaries">
+            <ae-button
+              @click="removeAppName = app.name"
+              class="remove-app-btn"
+              :class="{ visible: editModeActive }"
+              type="dramatic"
+              size="small"
+            >
+              <ae-icon slot="icon" invert type="exciting" name="close" />
+            </ae-button>
+            <router-link :to="app.path">
+              <ae-app-icon :src="app.icon" />
+            </router-link>
+          </div>
+          <router-link :to="app.path">
+            <div class="app-name">{{app.name}}</div>
+          </router-link>
       </div>
 
       <router-link to="add-app" class="app-shortcut">
         <ae-app-icon src="static/icons/notary.svg" />
-        <div class="app-name">Add App</div>
+        <div class="app-name extra-top-margin">Add App</div>
       </router-link>
     </div>
 


### PR DESCRIPTION
#71 was appearing when the label for a aepp is wider than the icon (i.e. Æddress Book).

[![bs_realdroid_Mobile_Samsung_Galaxy_S4-4.4-1080x1920.jpg](https://s13.postimg.org/gjkzv1jl3/bs_realdroid_Mobile_Samsung_Galaxy_S4-4.4-1080x1920.jpg)](https://postimg.org/image/w52bezvj7/)

