### PR TITLE
Fix 69 / Onboarding: limit main content's width

### DIFF
--- a/src/pages/Onboarding/Onboarding.scss
+++ b/src/pages/Onboarding/Onboarding.scss
@@ -2,11 +2,22 @@
 @import './../../text.style.scss';
 
 .onBoarding {
+  .wrapper{
+    align-items: center;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+  }
+
   header {
+    box-sizing: border-box;
     padding: 30px;
+    width: 100%;
   }
 
   .main-content-container{
+    max-width: 650px;
     width: 100%;
   }
 


### PR DESCRIPTION
This is a continuation to #79. After getting the required information I implemented a max-with of 650px to the main content.

[![fix-69.png](https://s14.postimg.org/c26uzqpwh/fix-69.png)](https://postimg.org/image/otl168zod/)