### PR TITLE
fix transfer to own address without swiping

### DIFF
--- a/src/pages/Transfer/Transfer.js
+++ b/src/pages/Transfer/Transfer.js
@@ -94,6 +94,9 @@ export default {
         initialSlide: this.identitiesTo.findIndex(i => i.address === this.to),
         onSlideChangeEnd: swiper => {
           this.to = this.identitiesTo[swiper.realIndex].address
+        },
+        onInit: swiper => {
+          this.to = this.identitiesTo[swiper.realIndex].address
         }
       }
     }


### PR DESCRIPTION
sets the "to" address when internal address is chosen and swiper is not swiped.

currently the to address only gets changed in the "onSlideChangeEnd" event