### PR TITLE
Enable vuex strict mode in not production

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -20,6 +20,7 @@ Bluebird.promisifyAll(Keystore)
 abiDecoder.addABI(AEToken.abi)
 
 const store = new Vuex.Store({
+  strict: process.env.NODE_ENV !== 'production',
   plugins: [
     createPersistedState({
       paths: ['apps', 'rpcUrl', 'keystore', 'selectedIdentityIdx', 'addressBook']


### PR DESCRIPTION
To change Vue state only in mutations is a concern to be a good practice. `strict` mode raises the exception when the state changed outside of mutations, but is required some resources so it is better to disable it in production mode.