### PR TITLE
Don't commit 'setBalance' if balance the same

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -8,6 +8,7 @@ import Transaction from 'ethereumjs-tx'
 import abiDecoder from 'abi-decoder'
 import util from 'ethereumjs-util'
 import Bluebird from 'bluebird'
+import _ from 'lodash'
 import AEToken from '@/assets/contracts/AEToken.json'
 import {
   approveTransaction as approveTransactionDialog,
@@ -156,11 +157,12 @@ const store = new Vuex.Store({
       getters.keystore.getAddresses().forEach(address =>
         dispatch('updateBalance', address))
     },
-    async updateBalance ({getters: { web3, tokenContract }, commit}, address) {
+    async updateBalance ({ state, getters: { web3, tokenContract }, commit }, address) {
       const [balance, tokenBalance] = await Promise.all([
         web3.eth.getBalance(address),
         tokenContract ? tokenContract.methods.balanceOf(address).call() : NaN
       ])
+      if (_.isEqual(state.balances[address], { balance, tokenBalance })) return
       commit('setBalance', { address, balance, tokenBalance })
     },
     async createKeystore ({ commit, dispatch, state }, password) {


### PR DESCRIPTION
`updateBalance` usually called in an interval. It makes a lot of mutation calls and most of this mutations set the same balance. It brings a bunch of useless records in Vue dev tools, so I propose to commit mutation only if balance changed.