### PR TITLE
Updated identity component

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"
   },
   "dependencies": {
-    "@aeternity/aepp-components": "git+https://github.com/aeternity/aepp-components.git#update-identities",
+    "@aeternity/aepp-components": "2.0.10",
     "abi-decoder": "^1.0.9",
     "babel-plugin-transform-es3-member-expression-literals": "^6.22.0",
     "babel-plugin-transform-es3-property-literals": "^6.22.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"
   },
   "dependencies": {
-    "@aeternity/aepp-components": "2.0.8",
+    "@aeternity/aepp-components": "git+https://github.com/aeternity/aepp-components.git#update-identities",
     "abi-decoder": "^1.0.9",
     "babel-plugin-transform-es3-member-expression-literals": "^6.22.0",
     "babel-plugin-transform-es3-property-literals": "^6.22.0",

--- a/src/components/QuickId.vue
+++ b/src/components/QuickId.vue
@@ -10,7 +10,7 @@
       <div class="vertical-ruler" />
     </template>
     <ae-identity-main :identity="identity" active collapsed />
-    <ae-icon name="chevron" class="chevron-icon" rotate="270" />
+    <ae-icon name="chevron" rotate="270" type="dramatic" invert />
   </ae-account-background>
 </template>
 
@@ -57,10 +57,6 @@
       height: 25px;
       border-right: 1px solid #ffffff;
       align-self: center;
-    }
-
-    .chevron-icon {
-      fill: #ffffff;
     }
   }
 </style>

--- a/src/components/QuickId.vue
+++ b/src/components/QuickId.vue
@@ -1,13 +1,14 @@
 <template>
   <ae-account-background class="quick-id" type="dramatic" @click="showIdManager">
-    <router-link
-      :to="{ name: 'apps' }"
-      @click.native.stop
-      class="back-button"
-      v-if="showBackButton"
-      tag="button"
-    />
-    <div class="vertical-ruler" v-if="showBackButton" />
+    <template v-if="showBackButton">
+      <router-link
+        :to="{ name: 'apps' }"
+        @click.native.stop
+        class="back-button"
+        tag="button"
+      />
+      <div class="vertical-ruler" />
+    </template>
     <ae-identity-main :identity="identity" active collapsed />
     <ae-icon name="chevron" class="chevron-icon" rotate="270" />
   </ae-account-background>

--- a/src/components/QuickId.vue
+++ b/src/components/QuickId.vue
@@ -44,19 +44,25 @@
     width: calc(100% - 40px);
     max-width: 350px;
     cursor: pointer;
+    align-items: center;
 
     .back-button {
       width: 25px;
-      height: auto;
+      height: 25px;
       background: url('/static/icons/grid.svg') no-repeat;
       background-size: contain;
     }
 
     .vertical-ruler {
       margin: 0 15px;
-      height: 25px;
-      border-right: 1px solid #ffffff;
-      align-self: center;
+      height: 30px;
+      background-color: rgba(#ffffff, .5);
+      width: 2px;
+    }
+
+    .ae-identity-light {
+      flex-grow: 1;
+      margin-right: 10px;
     }
   }
 </style>

--- a/src/components/QuickId.vue
+++ b/src/components/QuickId.vue
@@ -1,22 +1,25 @@
 <template>
-  <ae-identity class="quick-id" :identity="identity" active @click="showIdManager" collapsed>
+  <ae-account-background class="quick-id" type="dramatic" @click="showIdManager">
     <router-link
       :to="{ name: 'apps' }"
-      class="back"
-      slot="header-left"
-      v-if="showBackButton"
       @click.native.stop
+      class="back-button"
+      v-if="showBackButton"
+      tag="button"
     />
-  </ae-identity>
+    <div class="vertical-ruler" v-if="showBackButton" />
+    <ae-identity-main :identity="identity" active collapsed />
+    <ae-icon name="chevron" class="chevron-icon" rotate="270" />
+  </ae-account-background>
 </template>
 
 <script>
   import { mapGetters } from 'vuex'
-  import { AeIdentity, AeIcon } from '@aeternity/aepp-components'
+  import { AeAccountBackground, AeIdentityMain, AeIcon } from '@aeternity/aepp-components'
 
   export default {
     name: 'quick-id',
-    components: { AeIdentity, AeIcon },
+    components: { AeAccountBackground, AeIdentityMain, AeIcon },
     computed: mapGetters({
       identity: 'activeIdentity'
     }),
@@ -37,15 +40,26 @@
     bottom: 20px;
     left: 50%;
     transform: translateX(-50%);
+    width: calc(100% - 40px);
+    max-width: 350px;
+    cursor: pointer;
 
-    .back {
+    .back-button {
       width: 25px;
       height: auto;
       background: url('/static/icons/grid.svg') no-repeat;
       background-size: contain;
-      border-right: 2px solid #f1f4f7;
-      margin-right: 15px;
-      padding-right: 15px;
+    }
+
+    .vertical-ruler {
+      margin: 0 15px;
+      height: 25px;
+      border-right: 1px solid #ffffff;
+      align-self: center;
+    }
+
+    .chevron-icon {
+      fill: #ffffff;
     }
   }
 </style>

--- a/src/components/QuickId.vue
+++ b/src/components/QuickId.vue
@@ -1,5 +1,5 @@
 <template>
-  <ae-account-background class="quick-id" type="dramatic" @click="showIdManager">
+  <ae-identity-background class="quick-id" type="dramatic" @click="showIdManager">
     <template v-if="showBackButton">
       <router-link
         :to="{ name: 'apps' }"
@@ -9,18 +9,18 @@
       />
       <div class="vertical-ruler" />
     </template>
-    <ae-identity-main :identity="identity" active collapsed />
+    <ae-identity-light :identity="identity" active collapsed invert />
     <ae-icon name="chevron" rotate="270" type="dramatic" invert />
-  </ae-account-background>
+  </ae-identity-background>
 </template>
 
 <script>
   import { mapGetters } from 'vuex'
-  import { AeAccountBackground, AeIdentityMain, AeIcon } from '@aeternity/aepp-components'
+  import { AeIdentityBackground, AeIdentityLight, AeIcon } from '@aeternity/aepp-components'
 
   export default {
     name: 'quick-id',
-    components: { AeAccountBackground, AeIdentityMain, AeIcon },
+    components: { AeIdentityBackground, AeIdentityLight, AeIcon },
     computed: mapGetters({
       identity: 'activeIdentity'
     }),

--- a/src/pages/Accounts.vue
+++ b/src/pages/Accounts.vue
@@ -175,9 +175,9 @@
     }
 
     .inactive-accounts {
-      :not(:last-child):not(.before-active):not(.active) /deep/ .ae-identity {
+      & > *:not(:last-child):not(.before-active):not(.active) {
         padding-bottom: 35px;
-        margin-bottom: -20px;
+        margin-bottom: -24px;
       }
 
       .active {


### PR DESCRIPTION
This uses a yet not approved version of aepp-componenst (see https://github.com/aeternity/aepp-components/pull/94). 

It refactors QuickId using two new components, which were extracted out of aeIdentity
![screenshot-2018-4-20 aeternity identity 1](https://user-images.githubusercontent.com/20792999/39049642-967c7b5a-44a2-11e8-99e8-98412a18a104.png)

It uses the updated aeIdentity component to add a title and a smaller, truncated address into the header section
![screenshot-2018-4-20 aeternity identity 2](https://user-images.githubusercontent.com/20792999/39049792-35f1ffa2-44a3-11e8-893a-e27320355600.png)
![screenshot-2018-4-20 aeternity identity 3](https://user-images.githubusercontent.com/20792999/39049858-654fc37e-44a3-11e8-9975-efa68ed4cc76.png)

