### PR TITLE
Don't block QuickId while external aepp is loading

### DIFF
--- a/src/pages/AppBrowser/AppBrowser.scss
+++ b/src/pages/AppBrowser/AppBrowser.scss
@@ -19,7 +19,6 @@
     width: 100%;
     height: 100%;
     background-color: rgba(0,0,0,0.15);
-    z-index: 100;
     cursor: wait;
     opacity: 0;
     transition: opacity 2s, translate 0s 2s;


### PR DESCRIPTION
https://github.com/aeternity/aepp-identity/blob/945755f/src/pages/AppBrowser/AppBrowser.vue#L3-L5

`.loader` div is after iframe in the source code, so it will be above iframe, no `z-index` needed. Also `z-index` positioning `.loader` div above QuickId component and becomes impossible to close aepp until it is loaded.