### PR TITLE
QuickId: Render back button as link

### DIFF
--- a/src/components/QuickId.vue
+++ b/src/components/QuickId.vue
@@ -5,7 +5,6 @@
         :to="{ name: 'apps' }"
         @click.native.stop
         class="back-button"
-        tag="button"
       />
       <div class="vertical-ruler" />
     </template>


### PR DESCRIPTION
For some reason in some cases, CSS styles are applied in a different way in the app started by `npm run dev`, and `npm run build` served by some web server. #103 introduces back button of QuickId component rendered as a button instead of a hyperlink. It looks  okay in the local version, but when it deployed to stage it has borders:
![screenshot from 2018-05-02 15-45-44](https://user-images.githubusercontent.com/9007851/39527073-d766729c-4e20-11e8-9d73-a959feb2434a.png)
I don't see any reason to render it as a button, so proposing to revert previous behavior (this also fixes styles issue).