### PR TITLE
Step: Remove /deep/ inside another deep

### DIFF
--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -46,7 +46,7 @@
         width: 170px;
         display: inline-block;
 
-        /deep/ img {
+        img {
           width: 100%;
         }
       }


### PR DESCRIPTION
In this case, deep was passed to browser styles, but it is useless and not supported by some browsers (Firefox 60). Warning from Chromium 66:
> [Deprecation] /deep/ combinator is no longer supported in CSS dynamic profile.It is now effectively no-op, acting as if it were a descendant combinator. /deep/ combinator will be removed, and will be invalid at M65. You should remove it. See https://www.chromestatus.com/features/4964279606312960 for more details.
