### PR TITLE
Apps: Render icons in three columns on screens above 310px

### DIFF
--- a/src/pages/Apps/Apps.scss
+++ b/src/pages/Apps/Apps.scss
@@ -43,9 +43,9 @@
 
   .shortcuts {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
-    margin: 20px;
-    grid-gap: 20px;
+    grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+    margin: 10px;
+    grid-gap: 30px 10px;
     justify-items: center;
 
     @include abovePhone {
@@ -57,6 +57,7 @@
       display: flex;
       flex-direction: column;
       align-items: center;
+      width: 100%;
 
       .app-icon-wrapper {
         position: relative;
@@ -100,6 +101,10 @@
         font-size: 18px;
         font-weight: 500;
         text-align: center;
+        width: 100%;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
       }
 
       @include abovePhone {


### PR DESCRIPTION
| Before  | After |
| ------------- | ------------- |
| ![localhost_8080_ iphone 6_7_8 1](https://user-images.githubusercontent.com/9007851/40095752-f459ec96-58cd-11e8-8ce4-4bff836e1293.png) | ![localhost_8080_ iphone 6_7_8](https://user-images.githubusercontent.com/9007851/40095754-f6cdeb76-58cd-11e8-9ef8-224106e204b1.png)  |

https://www.pivotaltracker.com/story/show/157426263