### PR TITLE
Remove useless brackets around `new Class()`

### DIFF
--- a/src/dialogs/ApproveTransaction.js
+++ b/src/dialogs/ApproveTransaction.js
@@ -11,7 +11,7 @@ import {
   AeIdentityAvatar
 } from '@aeternity/aepp-components'
 
-const { fromWei } = (new Web3()).utils
+const { fromWei } = new Web3().utils
 
 const createValueStr = (value, decimal, currencySymbol = 'CHF') => {
   if (typeof value !== 'number' || isNaN(value)) {

--- a/src/pages/SettingsRemoteConnection.vue
+++ b/src/pages/SettingsRemoteConnection.vue
@@ -47,7 +47,7 @@
         Object.values(followers)
           .map(f => ({
             ...f,
-            disconnectedAt: (new Date(f.disconnectedAt)).toLocaleString(),
+            disconnectedAt: new Date(f.disconnectedAt).toLocaleString(),
             connected: isFollowerConnected[f.key]
           }))
     }),

--- a/src/store/plugins/remoteConnection.js
+++ b/src/store/plugins/remoteConnection.js
@@ -67,11 +67,11 @@ class RemoteConnection {
       socket.on('follower-disconnected', fKey => store.commit('followerDisconnected', fKey))
 
       socket.on('message-from-follower', (followerKey, request) =>
-        (new RpcPeer(
+        new RpcPeer(
           response => socket.emit('message-to-follower', followerKey, response), {
             signTransaction: args => store.dispatch('signTransaction', args),
             cancelTransaction: args => store.commit('cancelTransaction', args)
-          }))
+          })
           .processMessage(request))
     } else {
       socket.on('added-to-group', () => store.commit('setRemoteConnected', true))


### PR DESCRIPTION
I was wrong about operator precedence in JS.