### PR TITLE
Fix duplicate keys detected error

### DIFF
--- a/src/pages/AddApp/AddApp.vue
+++ b/src/pages/AddApp/AddApp.vue
@@ -50,8 +50,8 @@
     </ae-input>
     <ae-label>{{searchTerm ? 'Search results' : 'All æpps'}}</ae-label>
     <template v-for="(app, idx) in apps">
-      <ae-divider v-if="idx" :key="app.id" />
-      <div :key="app.id" class="app" :class="{ inactive: app.added }" @click="addApp(app.id)">
+      <ae-divider v-if="idx" :key="`${app.id}-divider`" />
+      <div :key="`${app.id}-app`" class="app" :class="{ inactive: app.added }" @click="addApp(app.id)">
         <ae-app-icon :src="app.icon" :full-size="app.iconFullSize" />
         <div class="content">
           <h2>{{app.name}}</h2>

--- a/src/pages/AddressBook.vue
+++ b/src/pages/AddressBook.vue
@@ -11,16 +11,16 @@
         :name="c.name"
         :address="c.address"
         @click="openIdx = openIdx === idx ? -1 : idx"
-        :key="idx"
+        :key="`${idx}-address`"
       >
         <ae-icon slot="icon" name="chevron" :rotate="idx === openIdx ? -90 : 90" />
       </address-book-item>
-      <div v-if="idx === openIdx" :key="idx" class="actions">
+      <div v-if="idx === openIdx" :key="`${idx}-actions`" class="actions">
         <router-link :to="{ name: 'transfer', params: { to: c.address } }">
           <ae-app-icon src="static/icons/aepps/transfer.svg" />
         </router-link>
       </div>
-      <ae-divider :key="idx" />
+      <ae-divider :key="`${idx}-divider`" />
     </template>
 
     <fixed-add-button quick-id :to="{ name: 'address-book-new' }" />

--- a/src/pages/AddressBookChoose.vue
+++ b/src/pages/AddressBookChoose.vue
@@ -7,7 +7,7 @@
   >
     <ae-divider />
     <template v-for="(c, idx) in addressBook">
-      <ae-link :to="path(c.address)" :key="idx">
+      <ae-link :to="path(c.address)" :key="`${idx}-address`">
         <address-book-item
           :name="c.name"
           :address="c.address"
@@ -15,7 +15,7 @@
           <ae-icon slot="icon" name="arrow" rotate="-45" />
         </address-book-item>
       </ae-link>
-      <ae-divider :key="idx" />
+      <ae-divider :key="`${idx}-divider`" />
     </template>
 
     <fixed-add-button quick-id :to="{ name: 'address-book-new' }" />


### PR DESCRIPTION
Fixes bugs introduced in 316904dca0cdf5485150ced318a0d3520041bbb4 and eae84199093e80ed87d524ba97e24e30505d6387.
Example:
```
[Vue warn]: Duplicate keys detected: '<key>'. This may cause an update error.
```