### PR TITLE
Split build process for mobile and desktop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ install:
 script:
 - npm run lint
 - npm run unit
+before_deploy:
+- export TARGET_DEVICE=`[[ $TRAVIS_BRANCH =~ ^(master|develop)$ ]] && echo "desktop"`
 - npm run build
 deploy:
   - provider: script

--- a/config/prod.env.js
+++ b/config/prod.env.js
@@ -1,6 +1,14 @@
 'use strict'
+
+const { TARGET_DEVICE } = process.env
+const IS_CORDOVA = process.env.IS_CORDOVA === 'true'
+
 module.exports = {
   NODE_ENV: '"production"',
   IS_STAGE: process.env.TRAVIS_BRANCH === 'stage',
-  IS_CORDOVA: process.env.IS_CORDOVA === 'true'
+  IS_CORDOVA,
+  TARGET_DEVICE:
+    TARGET_DEVICE && JSON.stringify(TARGET_DEVICE) ||
+    IS_CORDOVA && '"mobile"' ||
+    undefined
 }

--- a/config/prod.env.js
+++ b/config/prod.env.js
@@ -5,7 +5,6 @@ const IS_CORDOVA = process.env.IS_CORDOVA === 'true'
 
 module.exports = {
   NODE_ENV: '"production"',
-  IS_STAGE: process.env.TRAVIS_BRANCH === 'stage',
   IS_CORDOVA,
   TARGET_DEVICE:
     TARGET_DEVICE && JSON.stringify(TARGET_DEVICE) ||

--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,8 @@
 import { mapState } from 'vuex'
 import { AeMain, AeBanner, AeButton } from '@aeternity/aepp-components'
-import Accounts from './pages/Accounts.vue'
-import QuickId from './components/QuickId.vue'
-import FooterModal from './components/FooterModal.vue'
-import AccountsHorizontal from './components/AccountsHorizontal.vue'
-import RemoteConnectionPrompt from './components/RemoteConnectionPrompt.vue'
-import WaitingForConfirmation from './components/WaitingForConfirmation.vue'
+import FooterMobile from './components/FooterMobile'
+import FooterDesktop from './components/FooterDesktop'
 import RemoveAppModal from './components/RemoveAppModal.vue'
-import ApproveMessage from './dialogs/ApproveMessage.vue'
-import ApproveTransaction from './dialogs/ApproveTransaction.vue'
 import IS_MOBILE_DEVICE from './lib/isMobileDevice'
 
 export default {
@@ -17,41 +11,18 @@ export default {
     AeMain,
     AeBanner,
     AeButton,
-    QuickId,
-    FooterModal,
-    AccountsHorizontal,
-    RemoteConnectionPrompt,
-    WaitingForConfirmation,
     RemoveAppModal,
-    Accounts,
-    ApproveMessage,
-    ApproveTransaction
+    AppFooter: IS_MOBILE_DEVICE ? FooterMobile : FooterDesktop
   },
-  data: () => ({
-    IS_MOBILE_DEVICE
-  }),
   computed: {
-    ...mapState(['notification', 'showIdManager']),
-    ...mapState({
-      messageToApprove: ({ mobile }) => mobile.messageToApprove,
-      transactionToApprove: ({ mobile }) => Object.values(mobile.transactionsToApprove)[0],
-      showRemoteConnectionPrompt: ({ desktop }) => desktop.showRemoteConnectionPrompt,
-      transactionIdToSignByRemote: ({ desktop }) => desktop.transactionIdToSignByRemote
-    }),
-    displayQuickId () {
+    ...mapState(['notification']),
+    displayFooter () {
       const hideQuickIdOn = ['onboarding', 'login', 'recover', 'new-account', 'set-password']
       if (IS_MOBILE_DEVICE) hideQuickIdOn.push('intro')
       return !hideQuickIdOn.includes(this.$route.name)
     },
     showBackButton () {
       return !['intro', 'apps'].includes(this.$route.name)
-    }
-  },
-  methods: {
-    toggleDesktopFooter () {
-      if (this.transactionIdToSignByRemote) return
-      this.$store.commit(`toggle${this.$store.getters.loggedIn
-        ? 'IdManager' : 'RemoteConnectionPrompt'}`)
     }
   },
   created: function () {

--- a/src/App.scss
+++ b/src/App.scss
@@ -20,17 +20,4 @@
       vertical-align: text-bottom;
     }
   }
-
-  .modal-dialogs-wrapper {
-    width: 100%;
-    height: 100%;
-    position: fixed;
-    top: 0;
-    left: 0;
-    background-image: linear-gradient(to bottom, rgba(30,30,30,.9), rgba(50, 10, 60, .9));
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 1000000;
-  }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <ae-main
     id="app"
-    :class="{ 'quick-id-hidden': !displayQuickId }">
+    :class="{ 'quick-id-hidden': !displayFooter }">
     <router-view />
     <ae-banner v-if="notification">
       <img
@@ -20,33 +20,10 @@
         {{ notification.action.name }}
       </ae-button>
     </ae-banner>
-    <template v-if="displayQuickId">
-      <template v-if="IS_MOBILE_DEVICE">
-        <quick-id :show-back-button="showBackButton" />
-        <accounts v-if="showIdManager" />
-      </template>
-      <footer-modal
-        v-else
-        :show-back-button="showBackButton"
-        :closable="!transactionIdToSignByRemote"
-        @toggle="toggleDesktopFooter"
-      >
-        <remote-connection-prompt v-if="showRemoteConnectionPrompt" />
-        <waiting-for-confirmation v-if="transactionIdToSignByRemote" />
-        <accounts-horizontal v-if="showIdManager" />
-      </footer-modal>
-    </template>
-    <div
-      v-if="IS_MOBILE_DEVICE && (messageToApprove || transactionToApprove)"
-      class="modal-dialogs-wrapper"
-    >
-      <approve-message
-        v-if="messageToApprove"
-        v-bind="messageToApprove" />
-      <approve-transaction
-        v-if="transactionToApprove"
-        v-bind="transactionToApprove" />
-    </div>
+    <app-footer
+      v-if="displayFooter"
+      :show-back-button="showBackButton"
+    />
     <remove-app-modal />
   </ae-main>
 </template>

--- a/src/components/FixedAddButton.vue
+++ b/src/components/FixedAddButton.vue
@@ -1,6 +1,6 @@
 <template>
   <ae-button
-    :class="{ 'quick-id': quickId, mobile: IS_MOBILE_DEVICE }"
+    :class="{ 'quick-id': quickId, mobile: $globals.IS_MOBILE_DEVICE }"
     :to="to"
     class="fixed-add-button"
     type="dramatic"
@@ -16,17 +16,13 @@
 
 <script>
 import { AeButton, AeIcon } from '@aeternity/aepp-components'
-import IS_MOBILE_DEVICE from '../lib/isMobileDevice'
 
 export default {
   components: { AeButton, AeIcon },
   props: {
     to: { type: [Object, String], default: undefined },
     'quick-id': { type: Boolean, default: false }
-  },
-  data: () => ({
-    IS_MOBILE_DEVICE
-  })
+  }
 }
 </script>
 

--- a/src/components/FooterDesktop.vue
+++ b/src/components/FooterDesktop.vue
@@ -1,0 +1,45 @@
+<template>
+  <footer-modal
+    :show-back-button="showBackButton"
+    :closable="!transactionIdToSignByRemote"
+    @toggle="toggleDesktopFooter"
+  >
+    <remote-connection-prompt v-if="showRemoteConnectionPrompt" />
+    <waiting-for-confirmation v-if="transactionIdToSignByRemote" />
+    <accounts-horizontal v-if="showIdManager" />
+  </footer-modal>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+import FooterModal from './FooterModal.vue'
+import AccountsHorizontal from './AccountsHorizontal.vue'
+import RemoteConnectionPrompt from './RemoteConnectionPrompt.vue'
+import WaitingForConfirmation from './WaitingForConfirmation.vue'
+
+export default {
+  components: {
+    FooterModal,
+    AccountsHorizontal,
+    RemoteConnectionPrompt,
+    WaitingForConfirmation
+  },
+  props: {
+    showBackButton: { type: Boolean, default: false }
+  },
+  computed: {
+    ...mapState(['showIdManager']),
+    ...mapState({
+      showRemoteConnectionPrompt: ({ desktop }) => desktop.showRemoteConnectionPrompt,
+      transactionIdToSignByRemote: ({ desktop }) => desktop.transactionIdToSignByRemote
+    })
+  },
+  methods: {
+    toggleDesktopFooter () {
+      if (this.transactionIdToSignByRemote) return
+      this.$store.commit(`toggle${this.$store.getters.loggedIn
+        ? 'IdManager' : 'RemoteConnectionPrompt'}`)
+    }
+  }
+}
+</script>

--- a/src/components/FooterMobile.vue
+++ b/src/components/FooterMobile.vue
@@ -1,0 +1,56 @@
+<template>
+  <div>
+    <quick-id :show-back-button="showBackButton" />
+    <accounts v-if="showIdManager" />
+    <div
+      v-if="messageToApprove || transactionToApprove"
+      class="modal-dialogs-wrapper"
+    >
+      <approve-message
+        v-if="messageToApprove"
+        v-bind="messageToApprove"
+      />
+      <approve-transaction
+        v-if="transactionToApprove"
+        v-bind="transactionToApprove"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+import Accounts from '../pages/Accounts.vue'
+import QuickId from './QuickId.vue'
+import ApproveMessage from '../dialogs/ApproveMessage.vue'
+import ApproveTransaction from '../dialogs/ApproveTransaction.vue'
+
+export default {
+  components: { QuickId, Accounts, ApproveMessage, ApproveTransaction },
+  props: {
+    showBackButton: { type: Boolean, default: false }
+  },
+  computed: {
+    ...mapState(['showIdManager']),
+    ...mapState({
+      messageToApprove: ({ mobile }) => mobile.messageToApprove,
+      transactionToApprove: ({ mobile }) => Object.values(mobile.transactionsToApprove)[0]
+    })
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.modal-dialogs-wrapper {
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  background-image: linear-gradient(to bottom, rgba(30,30,30,.9), rgba(50, 10, 60, .9));
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000000;
+}
+</style>

--- a/src/lib/isMobileDevice.js
+++ b/src/lib/isMobileDevice.js
@@ -1,3 +1,7 @@
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#Mobile_Tablet_or_Desktop
 
-export default window.navigator.userAgent.includes('Mobi')
+const { TARGET_DEVICE } = process.env
+
+export default TARGET_DEVICE
+  ? TARGET_DEVICE === 'mobile'
+  : window.navigator.userAgent.includes('Mobi')

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ import { focus } from 'vue-focus'
 import App from './App.vue'
 import getRouter from './router/index'
 import store from './store'
+import IS_MOBILE_DEVICE from './lib/isMobileDevice'
 
 Validator.extend('min_value_exclusive', (value, [min]) => Number(value) > min)
 Validator.extend('url_http', (value) => {
@@ -44,6 +45,7 @@ if (process.env.NODE_ENV === 'development') {
 }
 
 Vue.config.productionTip = false
+Vue.prototype.$globals = { IS_MOBILE_DEVICE }
 
 /* eslint-disable no-new */
 new Vue({

--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -10,7 +10,7 @@
         slot="right"
         class="mute">{{ networkName }}</span>
     </item>
-    <template v-if="IS_MOBILE_DEVICE">
+    <template v-if="$globals.IS_MOBILE_DEVICE">
       <heading>Add-ons</heading>
       <item :to="{ name: 'settings-remote-connection' }">
         <img src="../../static/icons/remote-connect.svg" >
@@ -36,7 +36,6 @@ import MobilePage from '../components/MobilePage.vue'
 import SettingsHeading from '../components/SettingsHeading'
 import SettingsItem from '../components/SettingsItem'
 import networks from '../lib/networksRegistry'
-import IS_MOBILE_DEVICE from '../lib/isMobileDevice'
 
 export default {
   components: {
@@ -45,7 +44,6 @@ export default {
     Heading: SettingsHeading,
     Item: SettingsItem
   },
-  data: () => ({ IS_MOBILE_DEVICE }),
   computed: mapState({
     networkName: ({ rpcUrl }) => networks.find(n => n.url === rpcUrl).name
   }),

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -47,9 +47,9 @@ const store = new Vuex.Store({
     pollBalance,
     initEpoch,
     remoteConnection.plugin,
-    notificationOnRemoteConnection,
-    decryptAccounts,
-    aeppApi
+    aeppApi,
+    ...IS_MOBILE_DEVICE
+      ? [decryptAccounts, notificationOnRemoteConnection] : []
   ],
 
   modules: IS_MOBILE_DEVICE ? { mobile } : { desktop },

--- a/src/store/plugins/decryptAccounts.js
+++ b/src/store/plugins/decryptAccounts.js
@@ -1,9 +1,8 @@
 import { getHDWalletAccounts } from '@aeternity/hd-wallet'
-import IS_MOBILE_DEVICE from '../../lib/isMobileDevice'
 import AES from '../../lib/aes'
 
 export default store =>
-  IS_MOBILE_DEVICE && store.watch(
+  store.watch(
     ({ mobile: { keystore, accountCount, derivedKey } }) => [keystore, accountCount, derivedKey],
     async ([keystore, accountCount, derivedKey]) => {
       if (!keystore || !derivedKey) return


### PR DESCRIPTION
Ideally would be to remove dependencies that are used only on mobile (like `vue-qrcode-reader` package) when building a version for desktop and vice versa, but probably it is not possible with current Webpack version (`side-effects` key of package.json is not supported).