### PR TITLE
Improve Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 before_install:
 - npm i -g npm@6.1.0
 install:
-- npm install
+- travis_wait npm install
 script:
 - npm run lint
 - npm run unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
 - '8'
+cache:
+  directories:
+    - node_modules
 before_install:
 - npm i -g npm@6.1.0
 install:


### PR DESCRIPTION
`npm install` takes 197 seconds [before](https://travis-ci.org/aeternity/aepp-identity/builds/396947534?utm_source=github_status&utm_medium=notification), and [now](https://travis-ci.org/aeternity/aepp-identity/builds/397891633?utm_source=github_status&utm_medium=notification) it is just 19 seconds.
