### PR TITLE
MobilePageContent: Remove /deep/ inside another deep

### DIFF
--- a/src/components/MobilePageContent.scss
+++ b/src/components/MobilePageContent.scss
@@ -8,7 +8,7 @@
       max-width: 310px;
       margin: 15px auto;
 
-      /deep/ .inner .label {
+      .inner .label {
         margin: 0 auto;
       }
     }


### PR DESCRIPTION
This bug introduced in #136; #119 is similar PR.