### PR TITLE
Use bip39, hd-wallet packages from npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,8 +41,9 @@
       }
     },
     "@aeternity/bip39": {
-      "version": "github:aeternity/bip39#d7e72d68ae8ed58b02c7a0ae2534355f9271bf50",
-      "from": "github:aeternity/bip39",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@aeternity/bip39/-/bip39-0.1.0.tgz",
+      "integrity": "sha512-ppRs0WTPpBAFJ2sDxt9eT0risarxeD8ByQO2qFmoAkaeA7galyWkx82AL0G5QrqGPC8DC+0gjc6l6Q8ueuD3hA==",
       "requires": {
         "create-hash": "^1.1.0",
         "pbkdf2": "^3.0.9",
@@ -51,8 +52,9 @@
       }
     },
     "@aeternity/hd-wallet": {
-      "version": "github:aeternity/hd-wallet-js#a618b0c803a77596e22448510f35c282f5e3b2a6",
-      "from": "github:aeternity/hd-wallet-js",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@aeternity/hd-wallet/-/hd-wallet-0.1.1.tgz",
+      "integrity": "sha512-egOym3muvvt9Zh8vSMN4Po+jVJRNmvxMXsHxb9BWeyCEVVyq3fWCBF+L2bATfIHZygBvnJKJQWfpUZU8X9cCRw==",
       "requires": {
         "@babel/runtime": "^7.0.0-beta.46",
         "bip32-path": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "dependencies": {
     "@aeternity/aepp-components": "2.0.12",
     "@aeternity/aepp-sdk": "^0.15.0-0.1.0",
-    "@aeternity/bip39": "github:aeternity/bip39",
-    "@aeternity/hd-wallet": "github:aeternity/hd-wallet-js",
+    "@aeternity/bip39": "^0.1.0",
+    "@aeternity/hd-wallet": "^0.1.1",
     "@zxing/library": "0.7.0",
     "emoji-datasource-apple": "^4.0.3",
     "fuse.js": "^3.2.0",


### PR DESCRIPTION
Some of the dependencies of `hd-wallet` got updated and its broke the build of that package and also of [the Base app](https://travis-ci.org/aeternity/aepp-identity/builds/432837633#L543). I have [added](https://github.com/aeternity/hd-wallet-js/commit/ac9b7c8d197a043784f01fce495ef1126e1de129) `package-lock.json` with valid dependencies to `hd-wallet` package and pushed it to npm to avoid such stuff in future. Also, it will speed up the building of the Base app.