### PR TITLE
router: Extract common expression

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,28 +4,17 @@ import mobileRoutes from './routes/mobile';
 import commonRoutes from './routes/common';
 import AddToHomeScreenPrompt from '../pages/AddToHomeScreenPrompt.vue';
 
-const router = new Router();
-
-if (
-  process.env.IS_MOBILE_DEVICE &&
-  !process.env.IS_CORDOVA && !process.env.IS_PWA && !process.env.IS_IOS
-) {
-  router.addRoutes([{
-    path: '/',
-    component: AddToHomeScreenPrompt,
-  }]);
-}
-
-if (
-  process.env.IS_MOBILE_DEVICE &&
-  (process.env.IS_CORDOVA || process.env.IS_PWA || process.env.IS_IOS)
-) {
-  router.addRoutes(mobileRoutes);
-}
-
-if (!process.env.IS_MOBILE_DEVICE || process.env.IS_CORDOVA || process.env.IS_PWA) {
-  router.addRoutes(commonRoutes);
-}
+const router = new Router({
+  routes:
+    process.env.IS_MOBILE_DEVICE
+      ? (!process.env.IS_CORDOVA && !process.env.IS_PWA && !process.env.IS_IOS
+        && [{
+          path: '/',
+          component: AddToHomeScreenPrompt,
+        }])
+        || [...mobileRoutes, ...commonRoutes]
+      : commonRoutes,
+});
 
 store.watch(
   (state, { loggedIn }) => loggedIn,


### PR DESCRIPTION
https://github.com/aeternity/aepp-identity/pull/181#pullrequestreview-158925737
@sadiqevani actually, you are right, this code can be simplified. Also, this PR fixes the bug in #181: `commonRoutes` is not registered in the case if the app is opened in Safari on iOS.

It is possible just to define `IS_MOBILE_DEVICE` instead of `process.env.IS_MOBILE_DEVICE`, but it becomes less obvious what this value can be changed using env variables.

Also, redefining of this values like:
```js
const showAddToHomeScreenPrompt = !process.env.IS_CORDOVA && !process.env.IS_PWA;
if (process.env.IS_MOBILE_DEVICE && showAddToHomeScreenPrompt) {
  // ...
}
```
breaks removing of dead code by [DefinePlugin](https://webpack.js.org/plugins/define-plugin/#usage).

I don't know any other ways to improve it.