### PR TITLE
Fix QR code scanning on iOS

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -18,9 +18,6 @@
     <allow-navigation href="*" />
     <platform name="android">
         <allow-intent href="market:*" />
-        <config-file parent="/manifest" target="AndroidManifest.xml">
-            <uses-permission android:name="android.permission.CAMERA" />
-        </config-file>
     </platform>
     <platform name="ios">
         <allow-intent href="itms:*" />
@@ -41,5 +38,5 @@
         <variable name="ANDROID_HOST" value=" " />
         <variable name="ANDROID_PATHPREFIX" value="/" />
     </plugin>
-    <plugin name="cordova-plugin-android-permissions" spec="^1.0.0" />
+    <plugin name="cordova-plugin-qrscanner" spec="^2.6.0" />
 </widget>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1441,9 +1441,9 @@
       }
     },
     "@zxing/library": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.7.0.tgz",
-      "integrity": "sha512-VJ1cJaCWVF8MspnuyaZKGKlrSQLqQ5usgSap8uuCAvWGQ6W6OwN1NeGvnjhT+9hmnwkHK8XjaflvzaDBC7nKnw==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.8.3.tgz",
+      "integrity": "sha512-7PVM1JGKbAHeRyC9zbZIhJUZhWcNcLGcvK4bt92ihCp2QAXvUlPWb0zPK2ZiMKOzz2TldrUK3M+3cugapdH5Kg==",
       "requires": {
         "text-encoding": "^0.6.4",
         "ts-custom-error": "^2.2.1"
@@ -16870,7 +16870,7 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@aeternity/aepp-sdk": "^0.15.0-0.1.0",
     "@aeternity/bip39": "^0.1.0",
     "@aeternity/hd-wallet": "^0.2.0",
-    "@zxing/library": "0.7.0",
+    "@zxing/library": "^0.8.3",
     "emoji-datasource-apple": "^4.0.3",
     "fuse.js": "^3.2.0",
     "lodash-es": "^4.17.10",

--- a/src/components/HeaderMobile.vue
+++ b/src/components/HeaderMobile.vue
@@ -14,7 +14,7 @@
 
 <style lang="scss" scoped>
 .header-mobile {
-  margin: 20px 14px;
+  padding: 20px 14px;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/src/components/RemoteConnectionPrompt.vue
+++ b/src/components/RemoteConnectionPrompt.vue
@@ -30,7 +30,7 @@
 <script>
 import { mapState } from 'vuex';
 import { AeAppIcon } from '@aeternity/aepp-components';
-import renderQrCodeSvgBinary from '../lib/renderQrCodeSvgBinary';
+import renderQrCodeSvg from '../lib/renderQrCodeSvg';
 import Step from './Step.vue';
 
 export default {
@@ -48,7 +48,7 @@ export default {
   },
   methods: {
     renderQrCode() {
-      this.$refs.qrCode.replaceWith(renderQrCodeSvgBinary(Buffer.from(this.peerId, 'base64'), 170));
+      this.$refs.qrCode.replaceWith(renderQrCodeSvg(this.peerId, 170));
     },
   },
 };

--- a/src/lib/renderQrCodeSvg.js
+++ b/src/lib/renderQrCodeSvg.js
@@ -1,17 +1,6 @@
 import { BrowserQRCodeSvgWriter } from '@zxing/library/esm5/browser/BrowserQRCodeSvgWriter';
-import Mode from '@zxing/library/esm5/core/qrcode/decoder/Mode';
 import ErrorCorrectionLevel from '@zxing/library/esm5/core/qrcode/decoder/ErrorCorrectionLevel';
 import Encoder from '@zxing/library/esm5/core/qrcode/encoder/Encoder';
-
-class BinaryEncoder extends Encoder {
-  static chooseMode() {
-    return Mode.BYTE;
-  }
-
-  static appendBytes(content, mode, bits) {
-    content.forEach(byte => bits.appendBits(byte, 8));
-  }
-}
 
 class QRCodeFancySvgWriter extends BrowserQRCodeSvgWriter {
   FILL_COLOR = '#311b58'
@@ -81,4 +70,4 @@ class QRCodeFancySvgWriter extends BrowserQRCodeSvgWriter {
 
 export default (content, side) =>
   new QRCodeFancySvgWriter(document.createElement('div'))
-    .renderResult(BinaryEncoder.encode(content, ErrorCorrectionLevel.L), side, side, 0);
+    .renderResult(Encoder.encode(content, ErrorCorrectionLevel.L), side, side, 0);

--- a/src/pages/Apps.vue
+++ b/src/pages/Apps.vue
@@ -163,7 +163,7 @@ export default {
   .shortcuts {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
-    margin: 50px 10px 10px 10px;
+    margin: 30px 10px 10px 10px;
     grid-gap: 30px 10px;
     justify-items: center;
 

--- a/src/pages/SettingsRemoteConnectionNew.vue
+++ b/src/pages/SettingsRemoteConnectionNew.vue
@@ -19,7 +19,6 @@
 </template>
 
 <script>
-import ResultMetadataType from '@zxing/library/esm5/core/ResultMetadataType';
 import { BrowserQRCodeReader } from '@zxing/library/esm5/browser/BrowserQRCodeReader';
 import MobilePage from '../components/MobilePage.vue';
 
@@ -50,7 +49,7 @@ export default {
           undefined,
           this.$refs.qrCodeVideo,
         );
-        data = Buffer.from(result.resultMetadata.get(ResultMetadataType.BYTE_SEGMENTS)[0]);
+        data = Buffer.from(result.getText(), 'base64');
       } while (data.length !== 15);
 
       this.$store.commit('addFollower', {


### PR DESCRIPTION
WebView on iOS doesn't support WebRTC that is necessary for QR codes scanning using `@zxing/library` package. Looks reasonable to use Cordova plugin in this case. I have checked the most popular packages for Cordova: [cordova-plugin-qrscanner](https://www.npmjs.com/package/cordova-plugin-qrscanner), and [phonegap-plugin-barcodescanner](https://www.npmjs.com/package/phonegap-plugin-barcodescanner). Both of them are no supports scanning of raw data encoded in QR codes, so I have wrapped raw data into base64.
